### PR TITLE
Add mobile viewport tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>JrDevMentoring</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Bootstrap CSS is responsive and looks good in my desktop browser at different sizes, but wasn't looking right in my mobile browser

I looked and I would add this mobile viewport tag to the layout