### PR TITLE
[#42] add search by programming language to Communities#index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'aws-sdk', '< 2.0'
 gem 'figaro'
 gem 'activeadmin', '~> 1.0.0.pre1'
 gem 'pg'
+gem 'pg_search'
 gem 'simple_form'
 
 group :development, :test do
@@ -33,6 +34,7 @@ end
 
 group :test do
   gem 'shoulda-matchers', '~> 3.1'
+  gem 'database_cleaner'
 end
 
 group :production do

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -6,3 +6,12 @@
   background-color: #fcf8e3;
   border-color: #faebcc;
 }
+
+.language-form {
+  display: inline;
+  float: none;
+}
+
+#query {
+  width: 250px;
+}

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -1,6 +1,11 @@
 class CommunitiesController < AuthenticationController
   def index
-    @available_mentors = User.mentors if current_user.mentee?
-    @available_mentees = User.mentees if current_user.mentor?
+    if params[:query].present?
+      @available_mentors = Profile.mentors.search_for(params[:query]) if current_user.mentee?
+      @available_mentees = Profile.mentees.search_for(params[:query]) if current_user.mentor?
+    else
+      @available_mentors = Profile.mentors if current_user.mentee?
+      @available_mentees = Profile.mentees if current_user.mentor?
+    end
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,4 +1,5 @@
 class Profile < ActiveRecord::Base
+  include PgSearch
   belongs_to :user
 
   PLAN_TYPES = %w{mentor mentee}
@@ -15,6 +16,11 @@ class Profile < ActiveRecord::Base
 
   has_attached_file :avatar, :styles => { :medium => "300x300>", :thumb => "100x100>", :square => '200x200#' }, :default_url => "/images/:style/missing.png"
   validates_attachment_content_type :avatar, :content_type => /\Aimage\/.*\Z/
+
+  pg_search_scope :search_for, against: %i(coding_languages)
+
+  scope :mentors, -> {where("not_available=? and 'mentor'=ANY(plan_types)", false)}
+  scope :mentees, -> {where("not_available=? and 'mentee'=ANY(plan_types)", false)}
 
   def valid_plan_types
     plan_types.each do |type|

--- a/app/views/communities/index.erb
+++ b/app/views/communities/index.erb
@@ -17,10 +17,24 @@
 
   <!-- Tab panes -->
   <div class="tab-content">
-
+    <div class="row" style='padding: 10px;'>
+      <div class="col-md-4"></div>
+      <div class="col-md-4">
+        <%= form_tag communities_path, method: :get, class: 'form-inline language-form' do %>
+          <div class="form-group">
+            <%= text_field_tag :query, params[:query],
+            placeholder: 'Filter by programming language', type: :search, class: "form-control" %>
+          </div>
+          <%= button_tag(type: "submit", class: "btn btn-primary") do %>
+              <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="col-md-4"></div>
+    </div>
     <% if @available_mentees %>
       <div role="tabpanel" class="tab-pane active" id="mentees">
-        <%= render 'profiles/community_profile', users: @available_mentees, community_type: 'Mentees' %>
+        <%= render 'profiles/community_profile', profiles: @available_mentees, community_type: 'Mentees' %>
       </div>
     <% end %>
 
@@ -30,7 +44,7 @@
       <% else %>
         <div role="tabpanel" class="tab-pane" id="mentors">
       <% end %>
-        <%= render 'profiles/community_profile', users: @available_mentors, community_type: 'Mentors' %>
+        <%= render 'profiles/community_profile', profiles: @available_mentors, community_type: 'Mentors' %>
       </div>
     <% end %>
   </div>

--- a/app/views/profiles/_community_profile.erb
+++ b/app/views/profiles/_community_profile.erb
@@ -6,25 +6,25 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
 
-    <% if users.empty? %>
-      <div class='alert alert-warning text-center'>No available mentor/mentee at the moment. Kindly check back later</div>
+    <% if profiles.empty? %>
+      <div class='alert alert-warning text-center'>No available <%= community_type.downcase %> at the moment. Kindly check back later</div>
     <% end %>
 
     <ul class="list-unstyled">
-      <% users.each do |user| %>
+      <% profiles.each do |profile| %>
         <li>
           <div class='well row <%= cycle('', 'white-bg')%>'>
             <div class="col-sm-4 text-center">
-              <%= link_to user do %>
-                <%= image_tag user.profile.avatar.url(:thumb), class: 'user-index-avatar' %>
+              <%= link_to profile.user do %>
+                <%= image_tag profile.avatar.url(:thumb), class: 'profile-index-avatar' %>
               <% end %>
             </div>
             <div>
-              <%= link_to user do %>
-                <h3><%= user.profile.first_name %> <%= user.profile.last_name %></h3>
+              <%= link_to profile.user do %>
+                <h3><%= profile.first_name %> <%= profile.last_name %></h3>
               <% end %>
-              <h5><%= user.profile.city %>, <%= user.profile.state %>, <%= user.profile.country %></h5>
-              <h5><%= user.profile.coding_languages %></h5>
+              <h5><%= profile.city %>, <%= profile.state %>, <%= profile.country %></h5>
+              <h5><%= profile.coding_languages %></h5>
             </div>
           </div>
         </li>

--- a/spec/controllers/communities_controller_spec.rb
+++ b/spec/controllers/communities_controller_spec.rb
@@ -10,7 +10,7 @@ describe CommunitiesController do
       end
     end
 
-    describe 'for authenticated user' do
+    describe 'for authenticated user, basic search' do
       before :each do
         mentors = create_list(:user, 3)
         mentees = create_list(:user, 4)
@@ -23,8 +23,8 @@ describe CommunitiesController do
           FactoryGirl.create(:profile, :mentee, user: mentee)
         end
 
-        @available_mentors = User.mentors
-        @available_mentees = User.mentees
+        @available_mentors = Profile.mentors
+        @available_mentees = Profile.mentees
 
 
         user = create(:profile, plan_types: ['mentor', 'mentee']).user
@@ -42,6 +42,65 @@ describe CommunitiesController do
 
       it 'assigns all mentees as "mentees"' do
         expect(assigns[:available_mentees]).to eq @available_mentees
+      end
+    end
+
+    describe 'for authenticated user, language search' do
+      before :each do
+        mentors = create_list(:user, 3)
+        mentees = create_list(:user, 4)
+
+        search_users = create_list(:user, 4)
+
+        mentors.each do |mentor|
+          FactoryGirl.create(:profile, :mentor, user: mentor)
+        end
+
+        mentees.each do |mentee|
+          FactoryGirl.create(:profile, :mentee, user: mentee)
+        end
+
+        @ruby_mentor = FactoryGirl.create(:profile, :mentor,
+                                          user: search_users[0],
+                                          coding_languages: "ruby")
+        @ruby_mentee = FactoryGirl.create(:profile, :mentee,
+                                          user: search_users[0],
+                                          coding_languages: "ruby")
+
+        @python_mentor = FactoryGirl.create(:profile, :mentor,
+                                            user: search_users[2],
+                                            coding_languages: "python")
+        @python_mentee = FactoryGirl.create(:profile, :mentee,
+                                            user: search_users[3],
+                                            coding_languages: "python")
+
+        @available_mentors = Profile.mentors
+        @available_mentees = Profile.mentees
+
+
+        user = create(:profile, plan_types: ['mentor', 'mentee']).user
+        sign_in user
+        get :index, query: 'ruby'
+      end
+
+      it 'is a success' do
+        expect(response.status).to eq 200
+      end
+
+      it 'assigns correct mentors' do
+        expect(assigns[:available_mentors]).to include @ruby_mentor
+      end
+
+      it 'does not assign incorrect mentors' do
+        expect(assigns[:available_mentors]).not_to include @python_mentor
+      end
+
+      it 'assigns correct mentees' do
+        expect(assigns[:available_mentees]).to include @ruby_mentee
+      end
+
+      it 'assigns correct mentors' do
+        expect(assigns[:available_mentees]).not_to include @python_mentee
       end
     end
 

--- a/spec/models/profile_model_spec.rb
+++ b/spec/models/profile_model_spec.rb
@@ -89,4 +89,66 @@ describe Profile do
       end
     end
   end
+
+  describe "ClassMethods" do
+    before :all do
+      DatabaseCleaner.start
+      mentor_users = create_list(:user, 3)
+      mentee_users = create_list(:user, 4)
+      @mentors = []
+      @mentees = []
+      mentor_users.each_with_index do |mentor, index|
+        not_available = (index == 0 ? true : false)
+        @mentors << FactoryGirl.create(:profile, :mentor, user: mentor, not_available: not_available)
+      end
+
+      mentee_users.each_with_index do |mentee, index|
+        not_available = (index == 0 ? true : false)
+        @mentees << FactoryGirl.create(:profile, :mentee, user: mentee, not_available: not_available)
+      end
+
+      @available_mentors = Profile.mentors
+      @available_mentees = Profile.mentees
+    end
+
+    after :all do
+      DatabaseCleaner.clean
+    end
+
+    describe "#Mentors" do
+      it "lists all available mentors" do
+        expect(@available_mentors.count).to eq 2
+      end
+
+      it "doesn't list mentees" do
+        expect(@available_mentors).not_to include @mentees[0]
+      end
+
+      it "lists mentors" do
+        expect(@available_mentors).to include @mentors[1]
+      end
+
+      it "doesn't list unavailable mentors" do
+        expect(@available_mentors).not_to include @mentors[0]
+      end
+
+    end
+
+    describe "#Mentees" do
+      it "lists all available mentees" do
+        expect(@available_mentees.count).to eq 3
+      end
+
+      it "doesn't list mentors" do
+        expect(@available_mentees).not_to include @mentors[1]
+      end
+
+      it "lists mentors" do
+        expect(@available_mentees).to include @mentees[1]
+      end
+      it "doesn't list unavailable mentees" do
+        expect(@available_mentees).not_to include @mentees[0]
+      end
+    end
+  end
 end

--- a/spec/models/user_model_spec.rb
+++ b/spec/models/user_model_spec.rb
@@ -47,6 +47,7 @@ describe User do
 
   describe "ClassMethods" do
     before :all do
+      DatabaseCleaner.start
       @mentors = create_list(:user, 3)
       @mentees = create_list(:user, 4)
 
@@ -62,6 +63,10 @@ describe User do
 
       @available_mentors = User.mentors
       @available_mentees = User.mentees
+    end
+
+    after :all do
+      DatabaseCleaner.clean
     end
 
     describe "#Mentors" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'spec_helper'
 require 'rspec/rails'
 
 require 'devise'
+require 'database_cleaner'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Add DatabaseCleaner to both profile and user spec to clear out DB between tests.
Moved mentee/mentor to Profile since Communities#index was primarily returning profiles
and because the search was on Profile, not User. Added pg_search gem to allow for text
search since, currently, languages are a text field, not a drop down selection.