### PR TITLE
Slack channel link #35

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -25,6 +25,7 @@
           <li><%= link_to "Internships", internships_path %></li>
           <li><%= link_to "My Account", edit_user_registration_path %></li>
         <% end %>
+        <li><%= link_to "Chat in Slack", jrdevslack_path %></li>
         <li><%= link_to "About", about_path %></li>
         <li><%= link_to "Contact Us", new_contact_path %></li>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,12 +13,15 @@ Rails.application.routes.draw do
   resources :contacts
   resources :communities, only: :index
   get '/about' => 'pages#about'
+  get "/jrdevslack" => redirect("https://jr-dev-mentoring.slack.com")
 
   authenticated :user do
     root 'pages#dashboard', as: :authenticated_root
   end
 
   root 'pages#home'
+  
+  
 
 	match '*path', :to => 'application#routing_error', via: [:get, :post]
 end


### PR DESCRIPTION
**Request in Issue #35 to add link to the slack channel.**

**Notes:**

Originally requested via bitly shortener.  My personal feeling is that since the server is going to execute the URI, there's no need to shorten it.  Additionally, not removing the shortener adds a potential point of failure if the shortener service ever has issues or changes the link on us.

I set the redirect in the `routes.rb` & then inserted it in the `/app/layouts/_header.html.erb`.

**Testing:** 

I took a peak at the rspec testing & wasn't sure where to drop the test as the controllers aren't exactly the right spot due to the shared nature - since you don't have capybara (for the feature tests).  I kind of feel like using an assertion here with regex as rspec fails over to it would be the way to go since it's a global, not a controller test ... once again it's something that is pretty contentious on how people handle this stuff.

**References:**

- https://relishapp.com/rspec/rspec-rails/docs/matchers/redirect-to-matcher

- http://api.rubyonrails.org/classes/ActionDispatch/Assertions/ResponseAssertions.html#method-i-assert_redirected_to

- https://relishapp.com/rspec/rspec-rails/v/3-6/docs/feature-specs/feature-spec
